### PR TITLE
Enlever un catch dans création dans voitures.js

### DIFF
--- a/api-rustco/routes/voitures.js
+++ b/api-rustco/routes/voitures.js
@@ -138,16 +138,12 @@ router.post("/",
                 await db.collection("voitures").doc(docRef.id).update(voiture);
 
             })        
-            .catch(function(error) {
-                res.statusCode = 500;
-                return res.json({message: "error"})
-            });
 
             res.statusCode = 201;
             res.json({message: "La donnée a été ajoutée"});
         } catch {
             res.statusCode = 500;
-            res.json({message: "error 2"})
+            res.json({message: "error"})
         }
     }
 );


### PR DESCRIPTION
Le catch faisait planter le render à chaque fois
qu'une requête était mal faite, alors je l'ai
juste enlevé.