### PR TITLE
Corriger erreur cors Closes #84

### DIFF
--- a/api-rustco/routes/utilisateurs.js
+++ b/api-rustco/routes/utilisateurs.js
@@ -5,7 +5,6 @@ const bcrypt = require("bcrypt");
 const jwt = require('jsonwebtoken');
 const { check, validationResult } = require("express-validator");
 
-
 router.get("/initialize", async (req, res) => {
     const donneesTest = require("../data/mockUtilisateurs.js");
     donneesTest.forEach(async (utilisateur) => {
@@ -13,7 +12,7 @@ router.get("/initialize", async (req, res) => {
         await db.collection("utilisateurs").add(utilisateur);
     });
 
-   res.statusCode = 200;
+    res.statusCode = 200;
     res.json({ message: "Données initialisées" });
 });
 
@@ -254,6 +253,9 @@ router.delete("/:id", async (req, res)=>{
 
 //CONNEXION
 router.post("/connexion", async (req, res)=>{
+
+    // Website you wish to allow to connect
+    res.set('Access-Control-Allow-Origin', '*');
 
     //Récupe info du body
     const {courriel, password} = req.body;


### PR DESCRIPTION
J'ai ajouter cette ligne de code à la route
connexion
res.set('Access-Control-Allow-Origin', '*');

Elle permet au localhost ou toute autre source
d'accèder à cette route. Il faudra le changer
quand le site sera sur un vrai serveur pour
raisons de sécurité.