### PR TITLE
Enlever middleware authEmploye.js de Modification

### DIFF
--- a/api-rustco/routes/utilisateurs.js
+++ b/api-rustco/routes/utilisateurs.js
@@ -239,7 +239,7 @@ router.post("/",
  * Cette route permet de modifier un utilisateur
  * @route POST 
  */
-router.put("/:id", authEmploye,
+router.put("/:id",
     [
         //TODO: Fait la validation
     ],


### PR DESCRIPTION
Paul m'a dit qu'apparament, il faut que le client
puisse modifier son propre profile. authEmployer
empêchait ceci.