### PR TITLE
Changer champ prix pour total commande et factures

### DIFF
--- a/api-rustco/routes/commandes.js
+++ b/api-rustco/routes/commandes.js
@@ -93,7 +93,7 @@ router.post("/",
         // check("prix_achete").escape().trim().notEmpty().isString(),
         // check("description_en").escape().trim().notEmpty().isString(),
         // check("description_fr").escape().trim().notEmpty().isString(),
-        // check("image").escape().trim().notEmpty().isString(),
+        // check("image").escape().trim().notEmpty().isString()
     ],
     
     async (req, res) => {
@@ -162,7 +162,7 @@ router.post("/",
                 commande.date = dateToday;
                 commande.expedition = req.body.expedition;
                 commande.methode_de_paiement = req.body.methode_de_paiement;
-                commande.prix = req.body.prix;
+                commande.total = req.body.total;
                 commande.status = req.body.status;
                 commande.taxes = req.body.taxes;
                 commande.voitures = req.body.voitures

--- a/api-rustco/routes/factures.js
+++ b/api-rustco/routes/factures.js
@@ -159,7 +159,7 @@ router.post("/",
                 facture.date = dateToday;
                 facture.expedition = req.body.expedition;
                 facture.methode_de_paiement = req.body.methode_de_paiement;
-                facture.prix = req.body.prix;
+                facture.total = req.body.total;
                 facture.taxes = req.body.taxes;
                 facture.voitures = req.body.voitures
                 facture.utilisateur = req.body.utilisateur;


### PR DESCRIPTION
Paul voulait qu'on change le nom prix pour total.
Ça va aider à faire la différences entre les prix
des voitures et le prix total de la commande.