### PR TITLE
Corriger erreurs création de journal de connexion

### DIFF
--- a/api-rustco/routes/journalDeConnexion.js
+++ b/api-rustco/routes/journalDeConnexion.js
@@ -84,10 +84,10 @@ router.post("/",
                 const journalDeConnexion = {};
                 journalDeConnexion.id = docRef.id;
                 journalDeConnexion.utilisateur = req.body.userId;
-                journalDeConnexion.addressIP = req.body.addressIP;
+                journalDeConnexion.addressIP = req.body.adresseIP;
                 journalDeConnexion.date = dateToday;
 
-                await db.collection("voitures").doc(docRef.id).update(voiture);
+                await db.collection("journal_de_connexion").doc(docRef.id).update(journalDeConnexion);
 
             })        
 


### PR DESCRIPTION
-Dans la partie où il insert les données, il
essayait de les mettre dans voitures et il
essayait d'inserer voiture

-J'avais écrit addressIP au lieu de adresseIP à
quelques endroits.